### PR TITLE
스프링 배치 In-Memory -> RDB 옮기기 및 리팩터링

### DIFF
--- a/OneCoin/Server/build.gradle
+++ b/OneCoin/Server/build.gradle
@@ -56,6 +56,11 @@ dependencies {
 
 	// oauth2
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
+	// Spring Batch
+	implementation 'org.springframework.boot:spring-boot-starter-batch'
+	implementation 'org.springframework.boot:spring-boot-starter-quartz'
+	testImplementation 'org.springframework.batch:spring-batch-test'
 }
 
 tasks.named('test') {

--- a/OneCoin/Server/src/main/java/OneCoin/Server/ServerApplication.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/ServerApplication.java
@@ -1,10 +1,12 @@
 package OneCoin.Server;
 
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableBatchProcessing
 @EnableJpaAuditing
 @EnableScheduling
 @SpringBootApplication

--- a/OneCoin/Server/src/main/java/OneCoin/Server/batch/jobs/ChatMessageBatchConfig.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/batch/jobs/ChatMessageBatchConfig.java
@@ -1,0 +1,33 @@
+package OneCoin.Server.batch.jobs;
+
+import OneCoin.Server.batch.tasklets.ChatMessageTasklet;
+import OneCoin.Server.chat.service.ChatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class ChatMessageBatchConfig {
+    private final JobBuilderFactory jobBuilderFactory;
+    private final StepBuilderFactory stepBuilderFactory;
+    private final ChatService chatService;
+
+    @Bean
+    public Job saveChatMessageJob() {
+        return jobBuilderFactory.get("saveChatMessageJob")
+                .start(saveChatMessageStep())
+                .build();
+    }
+
+    @Bean
+    public Step saveChatMessageStep() {
+        return stepBuilderFactory.get("saveChatMessageStep")
+                .tasklet(new ChatMessageTasklet(chatService))
+                .build();
+    }
+}

--- a/OneCoin/Server/src/main/java/OneCoin/Server/batch/scheduler/ChatMessageBatchScheduler.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/batch/scheduler/ChatMessageBatchScheduler.java
@@ -1,0 +1,35 @@
+package OneCoin.Server.batch.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecutionException;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class ChatMessageBatchScheduler {
+    private final Job job;
+    private final JobLauncher jobLauncher;
+
+    @Scheduled(fixedDelay = 1, timeUnit = TimeUnit.DAYS)
+    public void executeJob() {
+        try {
+            jobLauncher.run(
+                    job,
+                    new JobParametersBuilder()
+                            .addString("datetime", LocalDateTime.now().toString())
+                            .toJobParameters()
+            );
+        } catch (JobExecutionException ex) {
+            System.out.println(ex.getMessage());
+            ex.printStackTrace();
+        }
+    }
+
+}

--- a/OneCoin/Server/src/main/java/OneCoin/Server/batch/tasklets/ChatMessageTasklet.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/batch/tasklets/ChatMessageTasklet.java
@@ -1,0 +1,23 @@
+package OneCoin.Server.batch.tasklets;
+
+import OneCoin.Server.chat.service.ChatService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatMessageTasklet implements Tasklet {
+    private final ChatService chatService;
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        chatService.saveInMemoryChatMessagesToRdb();
+        log.info("In-Memory ChatMessage saved to RDB");
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/controller/MessageInterceptor.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/controller/MessageInterceptor.java
@@ -1,40 +1,23 @@
 package OneCoin.Server.chat.controller;
 
-import OneCoin.Server.chat.constant.MessageType;
-import OneCoin.Server.chat.dto.ChatResponseDto;
-import OneCoin.Server.chat.entity.ChatMessage;
-import OneCoin.Server.chat.mapper.ChatMapper;
-import OneCoin.Server.chat.service.ChatRoomService;
-import OneCoin.Server.chat.service.ChatService;
-import OneCoin.Server.config.webSocketAuth.WebSocketAuthService;
-import OneCoin.Server.chat.repository.vo.UserInfoInChatRoom;
 import OneCoin.Server.config.auth.utils.UserUtilsForWebSocket;
 import OneCoin.Server.exception.BusinessLogicException;
 import OneCoin.Server.exception.ExceptionCode;
 import OneCoin.Server.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.event.EventListener;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
-import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
 @Slf4j
 @RequiredArgsConstructor
 public class MessageInterceptor implements ChannelInterceptor {
     private final UserUtilsForWebSocket userUtilsForWebSocket;
-    private final ChatRoomService chatRoomService;
-    private final WebSocketAuthService webSocketAuthService;
-    private final ChatService chatService;
-    private final ChatMapper chatMapper;
-    private final RedisTemplate<Object, Object> redisTemplate;
-    private final ChannelTopic channelTopic;
+    private final RegisterController registerController;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -43,54 +26,26 @@ public class MessageInterceptor implements ChannelInterceptor {
         String sessionId = accessor.getSessionId();
         if (StompCommand.CONNECT.equals(command)) {
             log.info("[CONNECT] start {}", sessionId);
-            webSocketAuthService.authenticate(accessor);
+            registerController.authenticate(accessor);
             log.info("[CONNECT] complete {}", sessionId);
         } else if (StompCommand.SUBSCRIBE.equals(command)) {
             log.info("[SUBSCRIBE] start {}", sessionId);
             Integer chatRoomId = parseRoomIdFromHeader(accessor); //채팅 구독이 아니면 null반환
             User user = userUtilsForWebSocket.extractUser(accessor.getUser()); //비회원은 null을 반환
-            registerUserAndSendEnterMessage(sessionId, chatRoomId, user);
+            registerController.registerUserAndSendEnterMessage(sessionId, chatRoomId, user);
             log.info("[SUBSCRIBE] complete {}", sessionId);
         } else if (StompCommand.UNSUBSCRIBE.equals(command)) {
             log.info("[UNSUBSCRIBE] start {}", sessionId);
-            unregisterUserAndSendLeaveMessage(sessionId);
+            registerController.unregisterUserAndSendLeaveMessage(sessionId);
             log.info("[UNSUBSCRIBE] complete {}", sessionId);
         } else if (StompCommand.DISCONNECT.equals(command)) {
             log.info("[DISCONNECT] start {}", sessionId);
-            unregisterUserAndSendLeaveMessage(sessionId);
+            registerController.unregisterUserAndSendLeaveMessage(sessionId);
             log.info("[DISCONNECT] complete {}", sessionId);
         }
         return message;
     }
 
-    @EventListener
-    public void onDisconnectEvent(SessionDisconnectEvent event) {
-        String sessionId = event.getSessionId();
-        log.info("[ABNORMAL DISCONNECT] unregister start : user {}", sessionId);
-        unregisterUserAndSendLeaveMessage(sessionId);
-        log.info("[ABNORMAL DISCONNECT] unregister complete : user {}", sessionId);
-    }
-
-
-    //구독시에는 유저 방 정보에 유저가 몇 명 있고, 누가 있는지만 저장
-    private void registerUserAndSendEnterMessage(String sessionId, Integer chatRoomId, User user) {
-        if (chatRoomId == null) return; //채팅 서비스가 아닌 경우
-        chatRoomService.saveUserToChatRoom(chatRoomId, sessionId, user);
-        if (user != null) { //로그인한 유저인 경우
-            ChatMessage messageToUse = chatService.makeEnterOrLeaveChatMessage(MessageType.ENTER, chatRoomId, user);
-            ChatResponseDto chatResponseDto = chatMapper.chatMessageToResponseDto(messageToUse);
-            redisTemplate.convertAndSend(channelTopic.getTopic(), chatResponseDto);
-        }
-    }
-
-    private void unregisterUserAndSendLeaveMessage(String sessionId) {
-        UserInfoInChatRoom user = chatRoomService.deleteUserFromChatRoom(sessionId);
-        if (user.getUser() != null) { //로그인한 유저인 경우
-            ChatMessage messageToUse = chatService.makeEnterOrLeaveChatMessage(MessageType.LEAVE, user.getChatRoomId(), user.getUser());
-            ChatResponseDto chatResponseDto = chatMapper.chatMessageToResponseDto(messageToUse);
-            redisTemplate.convertAndSend(channelTopic.getTopic(), chatResponseDto);
-        }
-    }
 
     private Integer parseRoomIdFromHeader(StompHeaderAccessor accessor) {
         try {

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/controller/RegisterController.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/controller/RegisterController.java
@@ -1,0 +1,63 @@
+package OneCoin.Server.chat.controller;
+
+import OneCoin.Server.chat.constant.MessageType;
+import OneCoin.Server.chat.dto.ChatResponseDto;
+import OneCoin.Server.chat.entity.ChatMessage;
+import OneCoin.Server.chat.mapper.ChatMapper;
+import OneCoin.Server.chat.repository.vo.UserInfoInChatRoom;
+import OneCoin.Server.chat.service.ChatRoomService;
+import OneCoin.Server.chat.service.ChatService;
+import OneCoin.Server.config.webSocketAuth.WebSocketAuthService;
+import OneCoin.Server.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RegisterController {
+    private final ChatRoomService chatRoomService;
+    private final ChatService chatService;
+    private final ChatMapper chatMapper;
+    private final RedisTemplate<Object, Object> redisTemplate;
+    private final ChannelTopic channelTopic;
+    private final WebSocketAuthService webSocketAuthService;
+
+    //구독시에는 유저 방 정보에 유저가 몇 명 있고, 누가 있는지만 저장
+    public void registerUserAndSendEnterMessage(String sessionId, Integer chatRoomId, User user) {
+        if (chatRoomId == null) return; //채팅 서비스가 아닌 경우
+        chatRoomService.saveUserInChatRoom(chatRoomId, sessionId, user);
+        if (user != null && chatRoomService.isUserInChatRoom(chatRoomId, user.getEmail())) { //로그인한 유저인 경우
+            ChatMessage messageToUse = chatService.makeEnterOrLeaveChatMessage(MessageType.ENTER, chatRoomId, user);
+            ChatResponseDto chatResponseDto = chatMapper.chatMessageToResponseDto(messageToUse);
+            redisTemplate.convertAndSend(channelTopic.getTopic(), chatResponseDto);
+        }
+    }
+
+    public void unregisterUserAndSendLeaveMessage(String sessionId) {
+        UserInfoInChatRoom user = chatRoomService.deleteUserFromChatRoom(sessionId);
+        if (user.getUser() != null) { //로그인한 유저인 경우
+            ChatMessage messageToUse = chatService.makeEnterOrLeaveChatMessage(MessageType.LEAVE, user.getChatRoomId(), user.getUser());
+            ChatResponseDto chatResponseDto = chatMapper.chatMessageToResponseDto(messageToUse);
+            redisTemplate.convertAndSend(channelTopic.getTopic(), chatResponseDto);
+        }
+    }
+
+    public void authenticate(StompHeaderAccessor accessor) {
+        webSocketAuthService.authenticate(accessor);
+    }
+
+    @EventListener
+    public void onDisconnectEvent(SessionDisconnectEvent event) {
+        String sessionId = event.getSessionId();
+        log.info("[ABNORMAL DISCONNECT] unregister start : user {}", sessionId);
+        unregisterUserAndSendLeaveMessage(sessionId);
+        log.info("[ABNORMAL DISCONNECT] unregister complete : user {}", sessionId);
+    }
+}

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/controller/RegisterController.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/controller/RegisterController.java
@@ -56,8 +56,6 @@ public class RegisterController {
     @EventListener
     public void onDisconnectEvent(SessionDisconnectEvent event) {
         String sessionId = event.getSessionId();
-        log.info("[ABNORMAL DISCONNECT] unregister start : user {}", sessionId);
         unregisterUserAndSendLeaveMessage(sessionId);
-        log.info("[ABNORMAL DISCONNECT] unregister complete : user {}", sessionId);
     }
 }

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/controller/RegisterController.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/controller/RegisterController.java
@@ -33,7 +33,7 @@ public class RegisterController {
     public void registerUserAndSendEnterMessage(String sessionId, Integer chatRoomId, User user) {
         if (chatRoomId == null) return; //채팅 서비스가 아닌 경우
         chatRoomService.saveUserInChatRoom(chatRoomId, sessionId, user);
-        if (user != null && chatRoomService.isUserInChatRoom(chatRoomId, user.getEmail())) { //로그인한 유저인 경우
+        if (user != null && chatRoomService.isUserInChatRoom(chatRoomId, user.getEmail()) ) { //로그인한 유저인 경우
             ChatMessage messageToUse = chatService.makeEnterOrLeaveChatMessage(MessageType.ENTER, chatRoomId, user);
             ChatResponseDto chatResponseDto = chatMapper.chatMessageToResponseDto(messageToUse);
             redisTemplate.convertAndSend(channelTopic.getTopic(), chatResponseDto);

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/entity/ChatMessage.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/entity/ChatMessage.java
@@ -4,18 +4,20 @@ package OneCoin.Server.chat.entity;
 import OneCoin.Server.chat.constant.MessageType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
-import org.hibernate.id.GUIDGenerator;
 
-import java.util.UUID;
+import javax.persistence.Entity;
+import javax.persistence.Id;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Entity
 public class ChatMessage {
+    @Id
     @JsonProperty("id")
-    private String id;
+    private String chatMessageId;
     @JsonProperty("type")
     private MessageType type;
     @JsonProperty("message")

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/entity/ChatMessage.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/entity/ChatMessage.java
@@ -4,6 +4,9 @@ package OneCoin.Server.chat.entity;
 import OneCoin.Server.chat.constant.MessageType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
+import org.hibernate.id.GUIDGenerator;
+
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -11,6 +14,8 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class ChatMessage {
+    @JsonProperty("id")
+    private String id;
     @JsonProperty("type")
     private MessageType type;
     @JsonProperty("message")

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/repository/ChatMessageRdbRepository.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/repository/ChatMessageRdbRepository.java
@@ -1,0 +1,9 @@
+package OneCoin.Server.chat.repository;
+
+import OneCoin.Server.chat.entity.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatMessageRdbRepository extends JpaRepository<ChatMessage, String> {
+}

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/repository/ChatMessageRdbRepository.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/repository/ChatMessageRdbRepository.java
@@ -4,6 +4,9 @@ import OneCoin.Server.chat.entity.ChatMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ChatMessageRdbRepository extends JpaRepository<ChatMessage, String> {
+    List<ChatMessage> findAllByChatRoomId(Integer chatRoomId);
 }

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/repository/ChatMessageRepository.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/repository/ChatMessageRepository.java
@@ -39,6 +39,7 @@ public class ChatMessageRepository {
         chatMessage.setChatMessageId(id);
         operations.leftPush(key, chatMessage);
     }
+
     public void removeAllInChatRoom(Integer chatRoomId) {
         redisTemplate.delete(getKey(chatRoomId));
     }
@@ -60,6 +61,7 @@ public class ChatMessageRepository {
     public Long getIndex(Integer chatRoomId, ChatMessage chatMessage) {
         return operations.lastIndexOf(getKey(chatRoomId), chatMessage);
     }
+
     private String getKey(Integer chatRoomId) {
         return "ChatRoom" + String.valueOf(chatRoomId) + "Message";
     }

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/repository/ChatMessageRepository.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/repository/ChatMessageRepository.java
@@ -37,7 +37,7 @@ public class ChatMessageRepository {
         String key = getKey(chatMessage.getChatRoomId());
         String id = UUID.randomUUID().toString();
         chatMessage.setChatMessageId(id);
-        operations.leftPush(key, chatMessage);
+        operations.rightPush(key, chatMessage);
     }
 
     public void removeAllInChatRoom(Integer chatRoomId) {
@@ -47,15 +47,17 @@ public class ChatMessageRepository {
     public List<ChatMessage> getMessageFromRoom(Integer chatRoomId) {
         String key = getKey(chatRoomId);
         Object results = operations.range(key, 0L, NUMBER_OF_CHATS_TO_SHOW - 1L);
-        return Arrays.asList(objectMapper.convertValue(results, ChatMessage[].class));
+        return objectToList(results);
     }
 
     public List<ChatMessage> findAll(Integer chatRoomId) {
-        return operations.range(getKey(chatRoomId), 0L, -1L);
+        Object results = operations.range(getKey(chatRoomId), 0L, -1L);
+        return objectToList(results);
     }
-
+    //인덱스 미포함
     public List<ChatMessage> findAllAfter(Integer chatRoomId, Long index) {
-        return operations.range(getKey(chatRoomId), 0, index);
+        Object results = operations.range(getKey(chatRoomId), index + 1L, Long.MAX_VALUE);
+        return objectToList(results);
     }
 
     public Long getIndex(Integer chatRoomId, ChatMessage chatMessage) {
@@ -64,6 +66,11 @@ public class ChatMessageRepository {
 
     private String getKey(Integer chatRoomId) {
         return "ChatRoom" + String.valueOf(chatRoomId) + "Message";
+    }
+
+    private List<ChatMessage> objectToList(Object obj) {
+        if(obj == null) return null;
+        return Arrays.asList(objectMapper.convertValue(obj, ChatMessage[].class));
     }
 
 }

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/repository/ChatMessageRepository.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/repository/ChatMessageRepository.java
@@ -5,13 +5,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Repository;
 
 import javax.annotation.PostConstruct;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -38,7 +36,7 @@ public class ChatMessageRepository {
     public void save(ChatMessage chatMessage) {
         String key = getKey(chatMessage.getChatRoomId());
         String id = UUID.randomUUID().toString();
-        chatMessage.setId(id);
+        chatMessage.setChatMessageId(id);
         operations.leftPush(key, chatMessage);
     }
     public void removeAllInChatRoom(Integer chatRoomId) {

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/repository/ChatMessageRepository.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/repository/ChatMessageRepository.java
@@ -3,6 +3,7 @@ package OneCoin.Server.chat.repository;
 import OneCoin.Server.chat.entity.ChatMessage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Repository;
@@ -10,38 +11,58 @@ import org.springframework.stereotype.Repository;
 import javax.annotation.PostConstruct;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 @Repository
 @RequiredArgsConstructor
 public class ChatMessageRepository {
+    public final long NUMBER_OF_CHATS_TO_SHOW = 50L;
     private final RedisTemplate<String, ChatMessage> redisTemplate;
-    // <chatRoomKey, ChatMessage>
-    private ZSetOperations<String, ChatMessage> operations;
     private final ObjectMapper objectMapper;
+    private final int MAX_CHAT_ROOM = 2;
+    private final int TTL_IN_DAYS = 3;
+    // <chatRoomKey, ChatMessage>
+    private ListOperations<String, ChatMessage> operations;
 
     //채팅방에 메시지 저장
     @PostConstruct
     private void init() {
-        operations = redisTemplate.opsForZSet();
+        operations = redisTemplate.opsForList();
+        for (int chatRoomId = 1; chatRoomId <= MAX_CHAT_ROOM; chatRoomId++) {
+            redisTemplate.expire(getKey(chatRoomId), TTL_IN_DAYS, TimeUnit.DAYS);
+        }
     }
 
     public void save(ChatMessage chatMessage) {
-        String key = makeKey(chatMessage.getChatRoomId());
-        operations.add(key, chatMessage, System.currentTimeMillis());
-//        operations.removeRange(chatRoomId, 5, -1);
+        String key = getKey(chatMessage.getChatRoomId());
+        String id = UUID.randomUUID().toString();
+        chatMessage.setId(id);
+        operations.leftPush(key, chatMessage);
+    }
+    public void removeAllInChatRoom(Integer chatRoomId) {
+        redisTemplate.delete(getKey(chatRoomId));
     }
 
-    public List<ChatMessage> getMessageFromRoomLimitN(Integer chatRoomId, Long limit) {
-        String key = makeKey(chatRoomId);
-        Object results = operations.reverseRangeByScore(key, Long.MIN_VALUE, Long.MAX_VALUE, 0L, limit);
+    public List<ChatMessage> getMessageFromRoom(Integer chatRoomId) {
+        String key = getKey(chatRoomId);
+        Object results = operations.range(key, 0L, NUMBER_OF_CHATS_TO_SHOW - 1L);
         return Arrays.asList(objectMapper.convertValue(results, ChatMessage[].class));
     }
 
-    public void removeAllInChatRoom(Integer chatRoomId) {
-        operations.removeRange(makeKey(chatRoomId), Long.MIN_VALUE, Long.MAX_VALUE);
+    public List<ChatMessage> findAll(Integer chatRoomId) {
+        return operations.range(getKey(chatRoomId), 0L, -1L);
     }
 
-    private String makeKey(Integer chatRoomId) {
+    public List<ChatMessage> findAllAfter(Integer chatRoomId, Long index) {
+        return operations.range(getKey(chatRoomId), 0, index);
+    }
+
+    public Long getIndex(Integer chatRoomId, ChatMessage chatMessage) {
+        return operations.lastIndexOf(getKey(chatRoomId), chatMessage);
+    }
+    private String getKey(Integer chatRoomId) {
         return "ChatRoom" + String.valueOf(chatRoomId) + "Message";
     }
 

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/repository/LastChatMessageSavedRepository.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/repository/LastChatMessageSavedRepository.java
@@ -1,0 +1,36 @@
+package OneCoin.Server.chat.repository;
+
+import OneCoin.Server.chat.entity.ChatMessage;
+import OneCoin.Server.chat.utils.ChatRoomUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+
+import javax.annotation.PostConstruct;
+
+@RequiredArgsConstructor
+@Repository
+public class LastChatMessageSavedRepository {
+    private final RedisTemplate<String, ChatMessage> redisTemplate;
+    private final ChatRoomUtils chatRoomUtils;
+    private final ObjectMapper objectMapper;
+    private ValueOperations<String, ChatMessage> operations;
+
+    @PostConstruct
+    private void init() {
+        operations = redisTemplate.opsForValue();
+    }
+
+    public void save(Integer chatRoomId, ChatMessage chatMessage) {
+        operations.set(chatRoomUtils.makeLastChatMessageKey(chatRoomId), chatMessage);
+    }
+
+    public ChatMessage get(Integer chatRoomId) {
+        return objectMapper.convertValue(
+                operations.get(chatRoomUtils.makeLastChatMessageKey(chatRoomId)),
+                ChatMessage.class
+                );
+    }
+}

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/repository/LastSavedRepository.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/repository/LastSavedRepository.java
@@ -28,9 +28,12 @@ public class LastSavedRepository {
     }
 
     public ChatMessage get(Integer chatRoomId) {
-        return objectMapper.convertValue(
-                operations.get(chatRoomUtils.makeLastChatMessageKey(chatRoomId)),
-                ChatMessage.class
-                );
+        Object chatMessage = operations.get(chatRoomUtils.makeLastChatMessageKey(chatRoomId));
+        if (chatMessage == null) return null;
+        return objectMapper.convertValue(chatMessage, ChatMessage.class);
+    }
+
+    public void delete(Integer chatRoomId) {
+        operations.getAndDelete(chatRoomUtils.makeLastChatMessageKey(chatRoomId));
     }
 }

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/repository/LastSavedRepository.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/repository/LastSavedRepository.java
@@ -12,7 +12,7 @@ import javax.annotation.PostConstruct;
 
 @RequiredArgsConstructor
 @Repository
-public class LastChatMessageSavedRepository {
+public class LastSavedRepository {
     private final RedisTemplate<String, ChatMessage> redisTemplate;
     private final ChatRoomUtils chatRoomUtils;
     private final ObjectMapper objectMapper;

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/repository/UserInChatRoomRepository.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/repository/UserInChatRoomRepository.java
@@ -44,7 +44,7 @@ public class UserInChatRoomRepository {
     }
 
     public List<UserInChatRoom> findAllByChatRoomId(Integer chatRoomId) {
-        return Arrays.asList(objectMapper.convertValue(hashOperations.values(chatRoomUtils.makeKey(chatRoomId)), UserInChatRoom[].class));
+        return objectToList(hashOperations.values(chatRoomUtils.makeKey(chatRoomId)));
     }
 
     public boolean contain(String chatRoomIdKey, String sessionId) {
@@ -52,6 +52,16 @@ public class UserInChatRoomRepository {
     }
 
     public UserInChatRoom findBySessionId(String chatRoomIdKey, String sessionId) {
-        return objectMapper.convertValue(hashOperations.get(chatRoomIdKey, sessionId), UserInChatRoom.class);
+        return objectToEntity(hashOperations.get(chatRoomIdKey, sessionId));
+    }
+
+    private List<UserInChatRoom> objectToList(Object obj) {
+        if (obj == null) return null;
+        return Arrays.asList(objectMapper.convertValue(obj, UserInChatRoom[].class));
+    }
+
+    private UserInChatRoom objectToEntity(Object obj) {
+        if (obj == null) return null;
+        return objectMapper.convertValue(obj, UserInChatRoom.class);
     }
 }

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/repository/UserInChatRoomRepository.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/repository/UserInChatRoomRepository.java
@@ -17,9 +17,9 @@ import java.util.List;
 public class UserInChatRoomRepository {
     private final ObjectMapper objectMapper;
     private final ChatRoomUtils chatRoomUtils;
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisTemplate<String, UserInChatRoom> redisTemplate;
     //<ChatRoomIdKey, SessionId, UserInChatRoom>
-    private HashOperations<String, String, Object> hashOperations;
+    private HashOperations<String, String, UserInChatRoom> hashOperations;
 
     @PostConstruct
     private void init() {

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/service/ChatRoomService.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/service/ChatRoomService.java
@@ -6,8 +6,8 @@ import OneCoin.Server.chat.entity.UserInChatRoom;
 import OneCoin.Server.chat.mapper.ChatRoomMapper;
 import OneCoin.Server.chat.repository.ChatRoomRepository;
 import OneCoin.Server.chat.repository.UserInChatRoomRepository;
-import OneCoin.Server.chat.utils.ChatRoomUtils;
 import OneCoin.Server.chat.repository.vo.UserInfoInChatRoom;
+import OneCoin.Server.chat.utils.ChatRoomUtils;
 import OneCoin.Server.exception.BusinessLogicException;
 import OneCoin.Server.exception.ExceptionCode;
 import OneCoin.Server.user.entity.User;
@@ -103,8 +103,8 @@ public class ChatRoomService {
 
     public boolean isUserInChatRoom(Integer chatRoomId, String email) {
         List<UserInChatRoom> users = userInChatRoomRepository.findAllByChatRoomId(chatRoomId);
-        for(UserInChatRoom user : users) {
-            if(user.getEmail().equals(email)) return true;
+        for (UserInChatRoom user : users) {
+            if (user.getEmail().equals(email)) return true;
         }
         return false;
     }

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/service/ChatRoomService.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/service/ChatRoomService.java
@@ -104,6 +104,7 @@ public class ChatRoomService {
     public boolean isUserInChatRoom(Integer chatRoomId, String email) {
         List<UserInChatRoom> users = userInChatRoomRepository.findAllByChatRoomId(chatRoomId);
         for (UserInChatRoom user : users) {
+            if(user == null) continue;
             if (user.getEmail().equals(email)) return true;
         }
         return false;

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/service/ChatRoomService.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/service/ChatRoomService.java
@@ -12,6 +12,7 @@ import OneCoin.Server.exception.BusinessLogicException;
 import OneCoin.Server.exception.ExceptionCode;
 import OneCoin.Server.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import net.bytebuddy.description.field.FieldDescription;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,8 +30,6 @@ public class ChatRoomService {
     private final ChatRoomUtils chatRoomUtils;
     private final ChatRoomMapper mapper;
 
-
-
     public List<ChatRoom> findAllChatRooms() {
         Set<String> chatRoomKeys = chatRoomRepository.findAll();
         return chatRoomKeys.stream()
@@ -47,15 +46,13 @@ public class ChatRoomService {
                 .numberOfChatters(numberOfSessions)
                 .build();
     }
+
     public long getNumberOfUserInChatRoom(Integer chatRoomId) {
         findVerifiedChatRoom(chatRoomId);
         return userInChatRoomRepository.getNumberOfUserInChatRoom(chatRoomId);
     }
-    public void saveUserToChatRoom(Integer chatRoomId, String sessionId) {
-        saveUserToChatRoom(chatRoomId, sessionId, null);
-    }
 
-    public void saveUserToChatRoom(Integer chatRoomId, String sessionId, User user) {
+    public void saveUserInChatRoom(Integer chatRoomId, String sessionId, User user) {
         boolean isValid = chatRoomRepository.contains(chatRoomId);
         if (!isValid) {
             makeChatRoom(chatRoomId);
@@ -103,5 +100,13 @@ public class ChatRoomService {
         if (!isValid) {
             throw new BusinessLogicException(ExceptionCode.INVALID_CHAT_ROOM_ID);
         }
+    }
+
+    public boolean inUserInChatRoom(Integer chatRoomId, String email) {
+        List<UserInChatRoom> users = userInChatRoomRepository.findAllByChatRoomId(chatRoomId);
+        for(UserInChatRoom user : users) {
+            if(user.getEmail().equals(email)) return true;
+        }
+        return false;
     }
 }

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/service/ChatRoomService.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/service/ChatRoomService.java
@@ -12,7 +12,6 @@ import OneCoin.Server.exception.BusinessLogicException;
 import OneCoin.Server.exception.ExceptionCode;
 import OneCoin.Server.user.entity.User;
 import lombok.RequiredArgsConstructor;
-import net.bytebuddy.description.field.FieldDescription;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -102,7 +101,7 @@ public class ChatRoomService {
         }
     }
 
-    public boolean inUserInChatRoom(Integer chatRoomId, String email) {
+    public boolean isUserInChatRoom(Integer chatRoomId, String email) {
         List<UserInChatRoom> users = userInChatRoomRepository.findAllByChatRoomId(chatRoomId);
         for(UserInChatRoom user : users) {
             if(user.getEmail().equals(email)) return true;

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/service/ChatService.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/service/ChatService.java
@@ -18,7 +18,6 @@ import java.util.Map;
 public class ChatService {
     private final ChatMessageRepository chatMessageRepository;
     private final UserUtilsForWebSocket userInfoUtils;
-    private final Long NUMBER_OF_CHATS_TO_SEND_WHEN_ENTER = 30L;
 
     public ChatMessage makeEnterOrLeaveChatMessage(MessageType messageType, Integer chatRoomId, User user) {
         ChatMessage chatMessage = ChatMessage.builder()
@@ -68,6 +67,6 @@ public class ChatService {
     }
 
     public List<ChatMessage> getChatMessages(Integer chatRoomId) {
-        return chatMessageRepository.getMessageFromRoomLimitN(chatRoomId, NUMBER_OF_CHATS_TO_SEND_WHEN_ENTER);
+        return chatMessageRepository.getMessageFromRoom(chatRoomId);
     }
 }

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/service/ChatService.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/service/ChatService.java
@@ -88,6 +88,7 @@ public class ChatService {
                 Long index = chatMessageRepository.getIndex(chatRoomId, lastSaved);
                 messages = chatMessageRepository.findAllAfter(chatRoomId, index);
             }
+            if(messages.size() == 0) return;
             ChatMessage latestMessage = messages.get(messages.size() - 1);
             lastSavedRepository.save(chatRoomId, latestMessage);
             chatMessageRdbRepository.saveAll(messages);

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/service/ChatService.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/service/ChatService.java
@@ -1,8 +1,11 @@
 package OneCoin.Server.chat.service;
 
 import OneCoin.Server.chat.entity.ChatMessage;
+import OneCoin.Server.chat.entity.ChatRoom;
+import OneCoin.Server.chat.repository.ChatMessageRdbRepository;
 import OneCoin.Server.chat.repository.ChatMessageRepository;
 import OneCoin.Server.chat.constant.MessageType;
+import OneCoin.Server.chat.repository.LastSavedRepository;
 import OneCoin.Server.config.auth.utils.UserUtilsForWebSocket;
 import OneCoin.Server.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +21,9 @@ import java.util.Map;
 public class ChatService {
     private final ChatMessageRepository chatMessageRepository;
     private final UserUtilsForWebSocket userInfoUtils;
+    private final ChatMessageRdbRepository chatMessageRdbRepository;
+    private final LastSavedRepository lastSavedRepository;
+    private final ChatRoomService chatRoomService;
 
     public ChatMessage makeEnterOrLeaveChatMessage(MessageType messageType, Integer chatRoomId, User user) {
         ChatMessage chatMessage = ChatMessage.builder()
@@ -68,5 +74,23 @@ public class ChatService {
 
     public List<ChatMessage> getChatMessages(Integer chatRoomId) {
         return chatMessageRepository.getMessageFromRoom(chatRoomId);
+    }
+
+    public void saveInMemoryChatMessagesToRdb() {
+        List<ChatRoom> chatRooms = chatRoomService.findAllChatRooms();
+        for(ChatRoom chatRoom : chatRooms) {
+            Integer chatRoomId = chatRoom.getChatRoomId();
+            ChatMessage lastSaved = lastSavedRepository.get(chatRoomId);
+            List<ChatMessage> messages;
+            if(lastSaved == null) {
+                messages = chatMessageRepository.findAll(chatRoomId);
+            } else {
+                Long index = chatMessageRepository.getIndex(chatRoomId, lastSaved);
+                messages = chatMessageRepository.findAllAfter(chatRoomId, index);
+            }
+            ChatMessage latestMessage = messages.get(messages.size() - 1);
+            lastSavedRepository.save(chatRoomId, latestMessage);
+            chatMessageRdbRepository.saveAll(messages);
+        }
     }
 }

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/utils/ChatRoomUtils.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/utils/ChatRoomUtils.java
@@ -7,6 +7,7 @@ public class ChatRoomUtils {
     public final String KEY_FOR_CHAT_ROOMS = "ChatRooms";
     private final String PREFIX_OF_KEY = "ChatRoom";
     private final String SUFFIX_OF_KEY = "Session";
+    private final String SUFFIX_OF_LAST_CHAT_KEY = "LastSavedKey";
 
     public Integer parseChatRoomId(String key) {
         String chatRoomIdAsString = key.replace(PREFIX_OF_KEY, "");
@@ -16,5 +17,9 @@ public class ChatRoomUtils {
 
     public String makeKey(Integer chatRoomId) {
         return PREFIX_OF_KEY + String.valueOf(chatRoomId) + SUFFIX_OF_KEY;
+    }
+
+    public String makeLastChatMessageKey(Integer chatRoomId) {
+        return PREFIX_OF_KEY + String.valueOf(chatRoomId) + SUFFIX_OF_LAST_CHAT_KEY;
     }
 }

--- a/OneCoin/Server/src/main/java/OneCoin/Server/chat/utils/ChatRoomUtils.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/chat/utils/ChatRoomUtils.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class ChatRoomUtils {
-    public final String KEY_FOR_CHAT_ROOMS = "chatRooms";
+    public final String KEY_FOR_CHAT_ROOMS = "ChatRooms";
     private final String PREFIX_OF_KEY = "ChatRoom";
     private final String SUFFIX_OF_KEY = "Session";
 

--- a/OneCoin/Server/src/main/java/OneCoin/Server/config/WebSocketConfig.java
+++ b/OneCoin/Server/src/main/java/OneCoin/Server/config/WebSocketConfig.java
@@ -1,17 +1,12 @@
 package OneCoin.Server.config;
 
 import OneCoin.Server.chat.controller.MessageInterceptor;
-import OneCoin.Server.chat.mapper.ChatMapper;
-import OneCoin.Server.chat.service.ChatRoomService;
-import OneCoin.Server.chat.service.ChatService;
-import OneCoin.Server.config.webSocketAuth.WebSocketAuthService;
+import OneCoin.Server.chat.controller.RegisterController;
 import OneCoin.Server.config.auth.utils.UserUtilsForWebSocket;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -25,12 +20,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @Order(Ordered.HIGHEST_PRECEDENCE + 99)
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     private final UserUtilsForWebSocket userUtilsForWebSocket;
-    private final ChatRoomService chatRoomService;
-    private final WebSocketAuthService webSocketAuthService;
-    private final ChatService chatService;
-    private final ChatMapper chatMapper;
-    private final RedisTemplate<Object, Object> redisTemplate;
-    private final ChannelTopic channelTopic;
+    private final RegisterController registerController;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -55,8 +45,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
         registration.interceptors(new MessageInterceptor(
-                userUtilsForWebSocket, chatRoomService, webSocketAuthService,
-                chatService, chatMapper, redisTemplate, channelTopic));
+                userUtilsForWebSocket, registerController));
     }
 
 

--- a/OneCoin/Server/src/test/java/OneCoin/Server/chat/repository/ChatMessageRdbRepositoryTest.java
+++ b/OneCoin/Server/src/test/java/OneCoin/Server/chat/repository/ChatMessageRdbRepositoryTest.java
@@ -1,0 +1,44 @@
+package OneCoin.Server.chat.repository;
+
+import OneCoin.Server.chat.entity.ChatMessage;
+import OneCoin.Server.chat.testUtil.WebSocketTestUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ChatMessageRdbRepositoryTest {
+    @Autowired
+    private ChatMessageRdbRepository chatMessageRdbRepository;
+    @Autowired
+    private WebSocketTestUtils webSocketTestUtils;
+    private Long numberOfChatsToCreate;
+    private int chatRoomId;
+
+    @BeforeAll
+    void saveTest() {
+        numberOfChatsToCreate = 120L;
+        chatRoomId = 1000;
+        for (long i = 1; i <= numberOfChatsToCreate; i++) {
+            ChatMessage chatMessage = webSocketTestUtils.chatMessageMaker(i, chatRoomId);
+            chatMessage.setChatMessageId(UUID.randomUUID().toString());
+            chatMessageRdbRepository.save(chatMessage);
+        }
+    }
+
+    @Test
+    void findTest() {
+        List<ChatMessage> messages = chatMessageRdbRepository.findAll();
+        assertThat(messages.size())
+                .isEqualTo(numberOfChatsToCreate.intValue());
+    }
+}

--- a/OneCoin/Server/src/test/java/OneCoin/Server/chat/repository/ChatMessageRdbRepositoryTest.java
+++ b/OneCoin/Server/src/test/java/OneCoin/Server/chat/repository/ChatMessageRdbRepositoryTest.java
@@ -40,4 +40,11 @@ public class ChatMessageRdbRepositoryTest {
         assertThat(messages.size())
                 .isEqualTo(numberOfChatsToCreate.intValue());
     }
+
+    @Test
+    void findAllByChatRoomIdTest() {
+        List<ChatMessage> chatMessageList = chatMessageRdbRepository.findAllByChatRoomId(chatRoomId);
+        assertThat(chatMessageList.size())
+                .isEqualTo(numberOfChatsToCreate.intValue());
+    }
 }

--- a/OneCoin/Server/src/test/java/OneCoin/Server/chat/repository/ChatMessageRdbRepositoryTest.java
+++ b/OneCoin/Server/src/test/java/OneCoin/Server/chat/repository/ChatMessageRdbRepositoryTest.java
@@ -3,7 +3,6 @@ package OneCoin.Server.chat.repository;
 import OneCoin.Server.chat.entity.ChatMessage;
 import OneCoin.Server.chat.testUtil.WebSocketTestUtils;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,7 +28,7 @@ public class ChatMessageRdbRepositoryTest {
         numberOfChatsToCreate = 120L;
         chatRoomId = 1000;
         for (long i = 1; i <= numberOfChatsToCreate; i++) {
-            ChatMessage chatMessage = webSocketTestUtils.chatMessageMaker(i, chatRoomId);
+            ChatMessage chatMessage = webSocketTestUtils.makeChatMessage(i, chatRoomId);
             chatMessage.setChatMessageId(UUID.randomUUID().toString());
             chatMessageRdbRepository.save(chatMessage);
         }

--- a/OneCoin/Server/src/test/java/OneCoin/Server/chat/repository/ChatMessageRepositoryTest.java
+++ b/OneCoin/Server/src/test/java/OneCoin/Server/chat/repository/ChatMessageRepositoryTest.java
@@ -8,13 +8,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ZSetOperations;
 
 import java.util.List;
-import java.util.Set;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.in;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -38,7 +35,7 @@ public class ChatMessageRepositoryTest {
         numberOfChatsToCreate = 120L;
         chatRoomId = 1000;
         for (long i = 1; i <= numberOfChatsToCreate; i++) {
-            chatMessageRepository.save(webSocketTestUtils.chatMessageMaker(i, chatRoomId));
+            chatMessageRepository.save(webSocketTestUtils.makeChatMessage(i, chatRoomId));
         }
     }
 
@@ -76,7 +73,7 @@ public class ChatMessageRepositoryTest {
         ChatMessage latest = chatMessageList.get(0);
         long numberOfChatsToCreate = 10;
         for (long i = 1; i <= numberOfChatsToCreate; i++) {
-            chatMessageRepository.save(webSocketTestUtils.chatMessageMaker(i, chatRoomId));
+            chatMessageRepository.save(webSocketTestUtils.makeChatMessage(i, chatRoomId));
         }
 
         //when

--- a/OneCoin/Server/src/test/java/OneCoin/Server/chat/repository/ChatMessageRepositoryTest.java
+++ b/OneCoin/Server/src/test/java/OneCoin/Server/chat/repository/ChatMessageRepositoryTest.java
@@ -2,8 +2,10 @@ package OneCoin.Server.chat.repository;
 
 import OneCoin.Server.chat.entity.ChatMessage;
 import OneCoin.Server.chat.testUtil.WebSocketTestUtils;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.ListOperations;
@@ -26,8 +28,6 @@ public class ChatMessageRepositoryTest {
     private RedisTemplate<String, ChatMessage> redisTemplate;
     // <chatRoomKey, ChatMessage>
     private ListOperations<String, ChatMessage> operations;
-    @Autowired
-    private ObjectMapper objectMapper;
 
     @BeforeEach
     void saveMessages() {
@@ -89,10 +89,20 @@ public class ChatMessageRepositoryTest {
         //given
         Long index = 10L;
         //when
+        List<ChatMessage> all = chatMessageRepository.findAll(chatRoomId);
         List<ChatMessage> chatMessageList = chatMessageRepository.findAllAfter(chatRoomId, index);
+
+        ChatMessage chatMessageAtIndexPlusOne = all.get(index.intValue() + 1);
+        ChatMessage lastMessageRetrieve = chatMessageList.get(0);
+        ChatMessage latestMessage = chatMessageList.get(chatMessageList.size() - 1);
         //then
         assertThat(chatMessageList.size())
-                .isEqualTo(11);
+                .isEqualTo(Long.valueOf(numberOfChatsToCreate - index - 1L).intValue());
+        //index 바로 다음부터
+        assertThat(chatMessageAtIndexPlusOne.getMessage())
+                .isEqualTo(lastMessageRetrieve.getMessage());
+        //가장 최근에 저장된 것까지 리턴
+        assertThat(latestMessage.getUserId())
+                .isEqualTo(numberOfChatsToCreate);
     }
-
 }

--- a/OneCoin/Server/src/test/java/OneCoin/Server/chat/repository/LastChatMessageSavedRepositoryTest.java
+++ b/OneCoin/Server/src/test/java/OneCoin/Server/chat/repository/LastChatMessageSavedRepositoryTest.java
@@ -1,0 +1,38 @@
+package OneCoin.Server.chat.repository;
+
+import OneCoin.Server.chat.entity.ChatMessage;
+import OneCoin.Server.chat.testUtil.WebSocketTestUtils;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+public class LastChatMessageSavedRepositoryTest {
+    @Autowired
+    private LastChatMessageSavedRepository lastChatMessageSavedRepository;
+    @Autowired
+    private WebSocketTestUtils webSocketTestUtils;
+
+    @Test
+    void saveAndGetTest() {
+        //given
+        int chatRoomId = 200;
+        Long userId = 500L;
+        ChatMessage chatMessage = webSocketTestUtils.makeChatMessage(userId, chatRoomId);
+        chatMessage.setChatMessageId(UUID.randomUUID().toString());
+
+        ChatMessage chatMessage2 = webSocketTestUtils.makeChatMessage(userId + 20L, chatRoomId);
+        chatMessage.setChatMessageId(UUID.randomUUID().toString());
+        //when
+        lastChatMessageSavedRepository.save(chatRoomId, chatMessage);
+        lastChatMessageSavedRepository.save(chatRoomId, chatMessage2);
+        ChatMessage chatMessageReceived = lastChatMessageSavedRepository.get(chatRoomId);
+        //then
+        assertThat(chatMessageReceived.getUserId())
+                .isEqualTo(userId + 20L);
+    }
+}

--- a/OneCoin/Server/src/test/java/OneCoin/Server/chat/repository/LastSavedRepositoryTest.java
+++ b/OneCoin/Server/src/test/java/OneCoin/Server/chat/repository/LastSavedRepositoryTest.java
@@ -11,9 +11,9 @@ import java.util.UUID;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @SpringBootTest
-public class LastChatMessageSavedRepositoryTest {
+public class LastSavedRepositoryTest {
     @Autowired
-    private LastChatMessageSavedRepository lastChatMessageSavedRepository;
+    private LastSavedRepository lastSavedRepository;
     @Autowired
     private WebSocketTestUtils webSocketTestUtils;
 
@@ -28,9 +28,9 @@ public class LastChatMessageSavedRepositoryTest {
         ChatMessage chatMessage2 = webSocketTestUtils.makeChatMessage(userId + 20L, chatRoomId);
         chatMessage.setChatMessageId(UUID.randomUUID().toString());
         //when
-        lastChatMessageSavedRepository.save(chatRoomId, chatMessage);
-        lastChatMessageSavedRepository.save(chatRoomId, chatMessage2);
-        ChatMessage chatMessageReceived = lastChatMessageSavedRepository.get(chatRoomId);
+        lastSavedRepository.save(chatRoomId, chatMessage);
+        lastSavedRepository.save(chatRoomId, chatMessage2);
+        ChatMessage chatMessageReceived = lastSavedRepository.get(chatRoomId);
         //then
         assertThat(chatMessageReceived.getUserId())
                 .isEqualTo(userId + 20L);

--- a/OneCoin/Server/src/test/java/OneCoin/Server/chat/service/ChatRoomServiceTest.java
+++ b/OneCoin/Server/src/test/java/OneCoin/Server/chat/service/ChatRoomServiceTest.java
@@ -162,7 +162,7 @@ public class ChatRoomServiceTest {
         given(userInChatRoomRepository.findAllByChatRoomId(any(Integer.class)))
                 .willReturn(users);
         //when
-        boolean isIn = chatRoomService.inUserInChatRoom(chatRoomId1, user.getEmail());
+        boolean isIn = chatRoomService.isUserInChatRoom(chatRoomId1, user.getEmail());
 
         //then
         assertThat(isIn)

--- a/OneCoin/Server/src/test/java/OneCoin/Server/chat/service/ChatRoomServiceTest.java
+++ b/OneCoin/Server/src/test/java/OneCoin/Server/chat/service/ChatRoomServiceTest.java
@@ -4,8 +4,8 @@ import OneCoin.Server.chat.entity.ChatRoom;
 import OneCoin.Server.chat.entity.UserInChatRoom;
 import OneCoin.Server.chat.repository.ChatRoomRepository;
 import OneCoin.Server.chat.repository.UserInChatRoomRepository;
-import OneCoin.Server.chat.utils.ChatRoomUtils;
 import OneCoin.Server.chat.repository.vo.UserInfoInChatRoom;
+import OneCoin.Server.chat.utils.ChatRoomUtils;
 import OneCoin.Server.exception.BusinessLogicException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -57,6 +57,7 @@ public class ChatRoomServiceTest {
         roomId2Key = chatRoomUtils.makeKey(chatRoomId2);
         keySet = Sets.newSet(roomId1Key, roomId2Key);
     }
+
     @Test
     void findAllChatRoomsTest() {
         //given
@@ -152,5 +153,19 @@ public class ChatRoomServiceTest {
         //then
         assertThat(actual.size())
                 .isEqualTo(1);
+    }
+
+    @Test
+    void isUserInChatRoomTest() {
+        //given
+        List<UserInChatRoom> users = List.of(user);
+        given(userInChatRoomRepository.findAllByChatRoomId(any(Integer.class)))
+                .willReturn(users);
+        //when
+        boolean isIn = chatRoomService.inUserInChatRoom(chatRoomId1, user.getEmail());
+
+        //then
+        assertThat(isIn)
+                .isTrue();
     }
 }

--- a/OneCoin/Server/src/test/java/OneCoin/Server/chat/service/SaveInMemoryChatToRdbTest.java
+++ b/OneCoin/Server/src/test/java/OneCoin/Server/chat/service/SaveInMemoryChatToRdbTest.java
@@ -1,0 +1,88 @@
+package OneCoin.Server.chat.service;
+
+import OneCoin.Server.chat.entity.ChatMessage;
+import OneCoin.Server.chat.repository.ChatMessageRdbRepository;
+import OneCoin.Server.chat.repository.ChatMessageRepository;
+import OneCoin.Server.chat.repository.ChatRoomRepository;
+import OneCoin.Server.chat.repository.LastSavedRepository;
+import OneCoin.Server.chat.testUtil.WebSocketTestUtils;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SaveInMemoryChatToRdbTest {
+    @Autowired
+    private ChatService chatService;
+    private Long numberOfChatsToCreate1;
+    private Integer chatRoomId1;
+    private Long numberOfChatsToCreate2;
+    private Integer chatRoomId2;
+    @Autowired
+    private ChatMessageRepository chatMessageRepository;
+    @Autowired
+    private WebSocketTestUtils webSocketTestUtils;
+    @Autowired
+    private ChatMessageRdbRepository chatMessageRdbRepository;
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+    @Autowired
+    private LastSavedRepository lastSavedRepository;
+
+    @BeforeAll
+    void init() {
+        numberOfChatsToCreate1 = 120L;
+        chatRoomId1 = 1;
+        numberOfChatsToCreate2 = 200L;
+        chatRoomId2 = 2;
+
+        chatRoomRepository.delete(chatRoomId1);
+        chatRoomRepository.delete(chatRoomId2);
+        chatRoomRepository.create(chatRoomId1);
+        chatRoomRepository.create(chatRoomId2);
+
+        lastSavedRepository.delete(chatRoomId1);
+        lastSavedRepository.delete(chatRoomId2);
+
+        chatMessageRepository.removeAllInChatRoom(chatRoomId1);
+        chatMessageRepository.removeAllInChatRoom(chatRoomId2);
+
+        saveMessages(1L, numberOfChatsToCreate1);
+    }
+
+    @Test
+    @DisplayName("처음 저장하는 경우")
+    void saveTest() {
+        chatService.saveInMemoryChatMessagesToRdb();
+        List<ChatMessage> chatMessageList = chatMessageRdbRepository.findAll();
+        assertThat(chatMessageList.size())
+                .isEqualTo(numberOfChatsToCreate1 * 2);
+    }
+
+    @Test
+    @DisplayName("이후에 저장하는 경우")
+    void saveTest_최초이후() {
+        //given
+        saveMessages(numberOfChatsToCreate1 + 1L, numberOfChatsToCreate2);
+        //when
+        chatService.saveInMemoryChatMessagesToRdb();
+        //then
+        List<ChatMessage> chatMessageList = chatMessageRdbRepository.findAllByChatRoomId(chatRoomId1);
+        assertThat(chatMessageList.size())
+                .isEqualTo(numberOfChatsToCreate2);
+    }
+
+    private void saveMessages(long from, long to) {
+        for (long i = from; i <= to; i++) {
+            chatMessageRepository.save(webSocketTestUtils.makeChatMessage(i, chatRoomId1));
+        }
+        for (long i = from; i <= to; i++) {
+            chatMessageRepository.save(webSocketTestUtils.makeChatMessage(i, chatRoomId2));
+        }
+    }
+}

--- a/OneCoin/Server/src/test/java/OneCoin/Server/chat/testUtil/WebSocketTestUtils.java
+++ b/OneCoin/Server/src/test/java/OneCoin/Server/chat/testUtil/WebSocketTestUtils.java
@@ -130,6 +130,7 @@ public class WebSocketTestUtils {
 
     public ChatMessage chatMessageMaker(long userId, Integer chatRoomId) {
         return new ChatMessage(
+                null,
                 MessageType.TALK,
                 "hello" + userId,
                 LocalDateTime.now().toString(),

--- a/OneCoin/Server/src/test/java/OneCoin/Server/chat/testUtil/WebSocketTestUtils.java
+++ b/OneCoin/Server/src/test/java/OneCoin/Server/chat/testUtil/WebSocketTestUtils.java
@@ -128,7 +128,7 @@ public class WebSocketTestUtils {
         return httpHeaders;
     }
 
-    public ChatMessage chatMessageMaker(long userId, Integer chatRoomId) {
+    public ChatMessage makeChatMessage(long userId, Integer chatRoomId) {
         return new ChatMessage(
                 null,
                 MessageType.TALK,


### PR DESCRIPTION
## 스프링 배치
1. 지난 저장 위치 기억하기
  LastChatMessageSavedRepository
2. RDB repository
   ChatMessageRdbRepository
3. 기존 레파지토리 redis 자료구조 변경 (ZSet -> List)
요청이 갑자기 많이들어올 경우, 같은 시간(milliSeconds 단위)로 Score가 입력되어, 하나의 스코어가 여러개의 엔티티를 가리키는 경우가 생김.
4. 서비스 로직 구현
5. SpringBatch 구현

## 리팩터링
1. 인터셉터에서 서비스 로직에게 처리를 위임하는 책임을 분리 -> RegisterController 
